### PR TITLE
Get rid of no-longer required explicit sqlite driver loading in tests.

### DIFF
--- a/tests/integration/sqlite_cat_test.py
+++ b/tests/integration/sqlite_cat_test.py
@@ -3,14 +3,10 @@ from __future__ import annotations
 
 import logging
 
-import intake
 import pandas as pd
 from pandas.testing import assert_frame_equal
 
 from intake_sqlite import SQLiteCatalog
-
-# pytest imports this package last, so plugin is not auto-added
-intake.register_driver(name="sqlite_cat", driver=SQLiteCatalog)
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/sqlite_src_test.py
+++ b/tests/integration/sqlite_src_test.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import logging
 
-import intake
 import pandas as pd
 from pandas.testing import assert_frame_equal
 
@@ -12,11 +11,6 @@ from intake_sqlite import (
     SQLiteSourceAutoPartition,
     SQLiteSourceManualPartition,
 )
-
-# pytest imports this package last, so plugin is not auto-added
-intake.register_driver(name="sqlite", driver=SQLiteSource)
-intake.register_driver(name="sqlite_auto", driver=SQLiteSourceAutoPartition)
-intake.register_driver(name="sqlite_manual", driver=SQLiteSourceManualPartition)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Something changed in the way that pytest was doing imports -- previously these drivers had to be explicitly registered, since it wasn't happening automatically (as it would in normal usage) but that was apparently no longer the case. In addition... it didn't like something about how the keyword arguments were being used int he driver registration (even though it previously worked) which was causing the integration tests to fail.  But now it works without these at all so... byeeeee.